### PR TITLE
graceful shutdown

### DIFF
--- a/worker/02_core_and_p2p.Dockerfile
+++ b/worker/02_core_and_p2p.Dockerfile
@@ -129,4 +129,10 @@ RUN chmod +x ./p2p/scripts/p2p_startup.py && chmod +x ./core/core_startup.py
 
 COPY devops/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
-CMD . /opt/sgxsdk/environment && /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
+##### FOR NOW TILL I FIND A WAY TO SET THESE INSIDE PYTHON :'(
+ENV LD_LIBRARY_PATH=/opt/intel/libsgx-enclave-common/aesm:/opt/sgxsdk/sdk_libs:/opt/sgxsdk/sdk_libs
+ENV PKG_CONFIG_PATH=:/opt/sgxsdk/pkgconfig:/opt/sgxsdk/pkgconfig
+ENV SGX_SDK=/opt/sgxsdk
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/sgxsdk/bin:/opt/sgxsdk/bin/x64:/opt/sgxsdk/bin:/opt/sgxsdk/bin/x64
+
+CMD ["/usr/bin/python", "/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/worker/devops/supervisord.conf
+++ b/worker/devops/supervisord.conf
@@ -20,6 +20,7 @@ stderr_logfile=/dev/fd/2
 stderr_logfile_maxbytes=0
 autostart=true
 autorestart=true
+stopsignal=INT
 
 [program:core]
 command=python3 /root/core/core_startup.py
@@ -29,7 +30,7 @@ stderr_logfile=/dev/fd/2
 stderr_logfile_maxbytes=0
 autostart=true
 autorestart=true
-
+stopsignal=TERM
 
 [program:p2p]
 command=python3 /root/p2p/scripts/p2p_startup.py
@@ -39,3 +40,4 @@ stderr_logfile=/dev/fd/2
 stderr_logfile_maxbytes=0
 autostart=true
 autorestart=true
+stopsignal=TERM

--- a/worker/scripts/core_startup.py
+++ b/worker/scripts/core_startup.py
@@ -7,8 +7,9 @@ import argparse
 SGX_ENV_PATH = '/opt/sgxsdk/environment'
 
 from enigma_docker_common.config import Config
-# from enigma_docker_common.logger import get_logger
+from enigma_docker_common.logger import get_logger
 
+logger = get_logger('worker.core-startup')
 
 required = ['RUST_BACKTRACE', 'SPID', 'PORT', 'ATTESTATION_RETRIES']
 
@@ -37,7 +38,7 @@ def map_log_level_to_exec_flags(loglevel: str) -> str:
         return ''
 
 
-if __name__ == '__main__':
+def main():
     parser = init_arg_parse()
     args = parser.parse_args()
 
@@ -55,8 +56,13 @@ if __name__ == '__main__':
 
     # wait for SGX service to start
     time.sleep(2)
-
+    env = os.environ.copy()
+    logger.error(f'Env: {env}')
     subprocess.call([f'{args.executable}', f'{debug_trace_flags}',
                      '-p', f'{port}',
                      '--spid', f'{spid}',
-                     '-r', f'{attestation_retries}'])
+                     '-r', f'{attestation_retries}'], env=env)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
When running supervisor with source environment it doesn't pass signals, so SIGTERM (docker stop) ends up not being graceful. Need a better way to fix it, but for now I just set the variables manually