### PR TITLE
BLD: give option to only clone client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,9 @@ clone-client:
 	${contract}
 	${client}
 
+clone-client-solo:
+	${client}
+
 build:
 	cd common_scripts; docker build -f common.Dockerfile -t enigma_common .
 	cd worker; docker build --build-arg DEBUG=${DEBUG} --build-arg SGX_MODE=${SGX_MODE} -f worker.Dockerfile -t enigmampc/worker_${ext}:${DOCKER_TAG} .


### PR DESCRIPTION
While in most cases `make clone-client` will work just fine, and it's convenient to have bundled in one command the two clones that are needed to build a client (that is `contract` + `client`), this locks them both to the same `BRANCH`, so we need to have the option to clone them separately to be able to specify different branches for each: for example when we have a matched branch in another repo, but only with one of the two.