### PR TITLE
Update CI - fix & confirmations=1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,4 +17,4 @@ jobs:
     - name: Run the tests
       run: |
         cp .env.template .env
-        MIN_CONFIRMATIONS=0 docker-compose up --exit-code-from client & sleep 60 && docker-compose exec -T client make test
+        docker-compose up --exit-code-from client & sleep 240 && docker-compose exec -T client make test


### PR DESCRIPTION
Increased the wait time between `docker-compose up`  and `make test` (from 1 to 4 minutes) in the Drone CI, since occasionally the tests would start before a full epoch passes from the worker login, or the workers have had time to log in.