### PR TITLE
BLD: configurable --from=contract by branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,4 +69,4 @@ build-compile-base:
 
 build-client:
 	cd common_scripts; docker build -f common.Dockerfile -t enigma_common .
-	cd client; docker build -f client.Dockerfile -t enigmampc/client:${DOCKER_TAG} .
+	cd client; docker build -f client.Dockerfile --build-arg DOCKER_TAG=${DOCKER_TAG} -t enigmampc/client:${DOCKER_TAG} .

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ build:
 	cd worker; docker build --build-arg DEBUG=${DEBUG} --build-arg SGX_MODE=${SGX_MODE} -f worker.Dockerfile -t enigmampc/worker_${ext}:${DOCKER_TAG} .
 	cd km; docker build --build-arg DEBUG=${DEBUG} --build-arg SGX_MODE=${SGX_MODE} -f km.Dockerfile -t enigmampc/key_management_${ext}:${DOCKER_TAG} .
 	cd contract; docker build -f contract.Dockerfile -t enigmampc/contract:${DOCKER_TAG} .
-	cd client; docker build -f client.Dockerfile -t enigmampc/client:${DOCKER_TAG} .
+	cd client; docker build -f client.Dockerfile --build-arg DOCKER_TAG=${DOCKER_TAG} -t enigmampc/client:${DOCKER_TAG} .
 
 build-km:
 	cd common_scripts; docker build -f common.Dockerfile -t enigma_common .

--- a/client/client.Dockerfile
+++ b/client/client.Dockerfile
@@ -1,3 +1,4 @@
+ARG DOCKER_TAG
 FROM ubuntu:18.04 as base
 
 RUN apt-get update && \
@@ -16,6 +17,7 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 
 ########################
+FROM enigmampc/contract:${DOCKER_TAG} AS contract
 FROM base
 
 WORKDIR /root
@@ -29,10 +31,11 @@ RUN pip3 install \
       --find-links=/root/wheels \
       -r requirements.txt
 
-
 COPY --from=gitclone_integration /integration-tests /root/integration-tests
 COPY --from=gitclone_contract /enigma-contract/enigma-js/lib/enigma-js.node.js /root/integration-tests/enigma-js/lib/enigma-js.node.js
-COPY --from=enigmampc/contract /root/enigma-contract/build /root/build
+
+
+COPY --from=contract /root/enigma-contract/build /root/build
 
 WORKDIR /root/integration-tests
 RUN yarn install


### PR DESCRIPTION
Up until now there was the following line:
```
COPY --from=enigmampc/contract /root/enigma-contract/build /root/build	
```
which was really executing always:
```
COPY --from=enigmampc/contract:latest /root/enigma-contract/build /root/build
```
but when we were using the `develop` branch, that did not work. This corrects that.

Also worth noting that `Remember that any arguments used in FROM commands need to be defined before the first build stage.` from this [article](https://medium.com/@tonistiigi/advanced-multi-stage-build-patterns-6f741b852fae) otherwise once gets an `invalid reference format` that has driven me crazy needlessly