### PR TITLE
fix is_ready.sh

### DIFF
--- a/is_ready.sh
+++ b/is_ready.sh
@@ -1,15 +1,5 @@
 #!/bin/bash
 
-WORKERS=$(
-    docker-compose ps |
-        grep -P 'worker|bootstrap' |
-        wc -l
-)
-
-if [[ "$WORKERS" -eq 0 ]]; then
-    exit 1
-fi
-
 REGISTERED_WORKERS_IN_KM=$(
     docker-compose logs --tail 1000 km |
         grep -P 'get_active_workers|Confirmed epoch with worker params' |
@@ -19,7 +9,7 @@ REGISTERED_WORKERS_IN_KM=$(
         wc -l
 )
 
-if [[ "$WORKERS" -ne "$REGISTERED_WORKERS_IN_KM" ]]; then
+if [[ "$REGISTERED_WORKERS_IN_KM" -eq 0 ]]; then
     exit 1
 fi
 


### PR DESCRIPTION
Fix the `is_ready.sh` script.
Now only checks if any worker is registered with km instead of waiting for every worker to be registered with km.