### PR TITLE
BUG: fixed typo in runtime_base.Dockerfile

### DIFF
--- a/worker/runtime_base.Dockerfile
+++ b/worker/runtime_base.Dockerfile
@@ -9,7 +9,7 @@ ARG OS_REVESION=bionic1
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     #### Base utilities ####
-    logrotate
+    logrotate \
     #### Core dependencies ####
     librocksdb-dev \
     libzmq5 \


### PR DESCRIPTION
Previous #82 introduced a bug, that this PR fixes. There was a missing "continuation of a line" that broke a multi-line command.