### PR TITLE
MAINT: making is_ready both Linux and Mac compatible

### DIFF
--- a/is_ready.sh
+++ b/is_ready.sh
@@ -1,13 +1,27 @@
 #!/bin/bash
 
-REGISTERED_WORKERS_IN_KM=$(
-    docker-compose logs --tail 1000 km |
-        grep -P 'get_active_workers|Confirmed epoch with worker params' |
-        tail -1 |
-        grep -Poi '0x[a-f0-9]+' |
-        sort -u |
-        wc -l
-)
+case "$(uname)" in
+	Darwin*)
+		REGISTERED_WORKERS_IN_KM=$(
+		    docker-compose logs --tail 1000 km |
+		        grep -E 'get_active_workers|Confirmed epoch with worker params' |
+		        tail -1 |
+		        grep -Eoi '0x[a-f0-9]+' |
+		        sort -u |
+		        wc -l
+		)
+		;;
+	*)
+		REGISTERED_WORKERS_IN_KM=$(
+		    docker-compose logs --tail 1000 km |
+		        grep -P 'get_active_workers|Confirmed epoch with worker params' |
+		        tail -1 |
+		        grep -Poi '0x[a-f0-9]+' |
+		        sort -u |
+		        wc -l
+		)
+		;;
+esac
 
 if [[ "$REGISTERED_WORKERS_IN_KM" -eq 0 ]]; then
     exit 1


### PR DESCRIPTION
`is_ready.sh` script depends on some parameters that are specific to the Linux/GNU version of `grep` not found in the MacOS/BSD version. This PR detects with OS version is running, and switches between the command that matches each version.