### PR TITLE
on KM startup, if the faucet service can not be found, a retry is performed every 30 senconds

### DIFF
--- a/km/scripts/km_startup.py
+++ b/km/scripts/km_startup.py
@@ -143,10 +143,8 @@ if __name__ == '__main__':  # noqa: C901
                 logger.critical(f'Failed to get enough ETH or ENG to start - {e}')
                 sys.exit(-2)
             except ConnectionError as e:
-                logger.critical(f'Failed to connect to remote address: {e}')
-                sleep_time = 30
-                logger.info(f'sleeping for {sleep_time} seconds')
-                time.sleep(sleep_time)
+                logger.error(f'Failed to connect to faucet at remote address: {e}')
+                time.sleep(30)
 
     logger.info(f'Getting enigma-contract...')
     enigma_address = provider.enigma_contract_address

--- a/km/scripts/km_startup.py
+++ b/km/scripts/km_startup.py
@@ -135,14 +135,18 @@ if __name__ == '__main__':  # noqa: C901
 
     #  will not try a faucet if we're in mainnet or testnet
     if env in ['COMPOSE', 'K8S']:
-        try:
-            get_initial_coins(eth_address, 'ETH', config)
-        except RuntimeError as e:
-            logger.critical(f'Failed to get enough ETH or ENG to start - {e}')
-            sys.exit(-2)
-        except ConnectionError as e:
-            logger.critical(f'Failed to connect to remote address: {e}')
-            sys.exit(-1)
+        while True:
+            try:
+                get_initial_coins(eth_address, 'ETH', config)
+                break
+            except RuntimeError as e:
+                logger.critical(f'Failed to get enough ETH or ENG to start - {e}')
+                sys.exit(-2)
+            except ConnectionError as e:
+                logger.critical(f'Failed to connect to remote address: {e}')
+                sleep_time = 30
+                logger.info(f'sleeping for {sleep_time} seconds')
+                time.sleep(sleep_time)
 
     logger.info(f'Getting enigma-contract...')
     enigma_address = provider.enigma_contract_address


### PR DESCRIPTION
The title is pretty self explanatory.
when the KM starts up and the faucet service is not yet available, it just crashes instead of retrying.